### PR TITLE
GP-860 - Port features from `comicrelief/omnipay-worldpay-cg-hosted`

### DIFF
--- a/src/Omnipay/WorldPayXML/Gateway.php
+++ b/src/Omnipay/WorldPayXML/Gateway.php
@@ -134,6 +134,28 @@ class Gateway extends AbstractGateway
         return $this->setParameter('pa_response', $value);
     }
 
+
+    /**
+     * Get the separate username if configured (more secure approach for basic auth) or fallback to merchant if not
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->parameters->get('username', $this->getParameter('merchant'));
+    }
+
+    /**
+     * Set basic auth username
+     *
+     * @param string $value
+     * @return Gateway
+     */
+    public function setUsername($value)
+    {
+        return $this->setParameter('username', $value);
+    }
+
     /**
      * Get password
      *

--- a/src/Omnipay/WorldPayXML/Message/PurchaseRequest.php
+++ b/src/Omnipay/WorldPayXML/Message/PurchaseRequest.php
@@ -368,14 +368,14 @@ class PurchaseRequest extends AbstractRequest
 
             $header = $card->addChild('header');
 
-            $header->addChild('applicationData', $appleData['header']['applicationData']);
             $header->addChild('ephemeralPublicKey', $appleData['header']['ephemeralPublicKey']);
             $header->addChild('publicKeyHash', $appleData['header']['publicKeyHash']);
             $header->addChild('transactionId', $appleData['header']['transactionId']);
+            $header->addChild('applicationData', $appleData['header']['applicationData']);
 
-            $card->addChild('data', $appleData['data']);
             $card->addChild('signature', $appleData['signature']);
             $card->addChild('version', $appleData['version']);
+            $card->addChild('data', $appleData['data']);
         } else {
             $card = $payment->addChild($codes[$this->getCard()->getBrand()]);
             $card->addChild('cardNumber', $this->getCard()->getNumber());
@@ -398,12 +398,12 @@ class PurchaseRequest extends AbstractRequest
             }
 
             $card->addChild('cvc', $this->getCard()->getCvv());
-        }
 
-        $address = $card->addChild('cardAddress')->addChild('address');
-        $address->addChild('street', $this->getCard()->getAddress1());
-        $address->addChild('postalCode', $this->getCard()->getPostcode());
-        $address->addChild('countryCode', $this->getCard()->getCountry());
+            $address = $card->addChild('cardAddress')->addChild('address');
+            $address->addChild('street', $this->getCard()->getAddress1());
+            $address->addChild('postalCode', $this->getCard()->getPostcode());
+            $address->addChild('countryCode', $this->getCard()->getCountry());
+        }
 
         $session = $payment->addChild('session');
         $session->addAttribute('shopperIPAddress', $this->getClientIP());

--- a/src/Omnipay/WorldPayXML/Message/PurchaseRequest.php
+++ b/src/Omnipay/WorldPayXML/Message/PurchaseRequest.php
@@ -111,6 +111,27 @@ class PurchaseRequest extends AbstractRequest
     }
 
     /**
+     * Get the separate username if configured (more secure approach for basic auth) or fallback to merchant if not
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->parameters->get('username', $this->getParameter('merchant'));
+    }
+
+    /**
+     * Set basic auth username
+     *
+     * @param string $value
+     * @return AbstractRequest
+     */
+    public function setUsername($value)
+    {
+        return $this->setParameter('username', $value);
+    }
+
+    /**
      * Get pa response
      *
      * @access public
@@ -444,7 +465,7 @@ class PurchaseRequest extends AbstractRequest
         $document->appendChild($node);
 
         $authorisation = base64_encode(
-            $this->getMerchant() . ':' . $this->getPassword()
+            $this->getUsername() . ':' . $this->getPassword()
         );
 
         $headers = [

--- a/src/Omnipay/WorldPayXML/Message/Response.php
+++ b/src/Omnipay/WorldPayXML/Message/Response.php
@@ -12,13 +12,21 @@ use Omnipay\Common\Message\RequestInterface;
  */
 class Response extends AbstractResponse
 {
+    /** @var string */
+    protected static $PAYMENT_STATUS_AUTHORISED             = 'AUTHORISED';
+    /** @var string */
+    protected static $PAYMENT_STATUS_CAPTURED               = 'CAPTURED';
+    /** @var string */
+    protected static $PAYMENT_STATUS_SETTLED_BY_MERCHANT    = 'SETTLED_BY_MERCHANT';
+    /** @var string */
+    protected static $PAYMENT_STATUS_SENT_FOR_AUTHORISATION = 'SENT_FOR_AUTHORISATION';
+    /** @var string */
+    protected static $PAYMENT_STATUS_CANCELLED              = 'CANCELLED';
+
     /**
-     * Constructor
-     *
      * @param RequestInterface $request Request
      * @param string           $data    Data
-     *
-     * @access public
+     * @throws InvalidResponseException if non-XML response received
      */
     public function __construct(RequestInterface $request, $data)
     {
@@ -29,11 +37,17 @@ class Response extends AbstractResponse
         }
 
         $responseDom = new DOMDocument;
-        $responseDom->loadXML($data);
+        if (!@$responseDom->loadXML($data)) {
+            throw new InvalidResponseException('Non-XML notification response received');
+        }
 
-        $this->data = simplexml_import_dom(
-            $responseDom->documentElement->firstChild->firstChild
+        $this->data = @simplexml_import_dom(
+            $responseDom->documentElement->firstChild // <notify> or <reply>
         );
+
+        if (empty($this->data)) {
+            throw new InvalidResponseException('Could not import response XML: ' . $data);
+        }
     }
 
     /**
@@ -92,42 +106,86 @@ class Response extends AbstractResponse
             97 => 'SECURITY BREACH'
         ];
 
-        $message = 'PENDING';
-
         if (isset($this->data->error)) {
-            $message = 'ERROR: ' . $this->data->error;
+            return 'ERROR: ' . $this->data->error; // Cast to string to get CDATA content
         }
 
-        if (isset($this->data->payment->ISO8583ReturnCode)) {
-            $returnCode = $this->data->payment->ISO8583ReturnCode->attributes();
+        $payment = $this->getOrder()->payment;
+        if (isset($payment->ISO8583ReturnCode)) {
+            $returnCode = $payment->ISO8583ReturnCode->attributes();
 
             foreach ($returnCode as $name => $value) {
                 if ($name == 'code') {
-                    $message = $codes[intval($value)];
+                    return $codes[intval($value)];
                 }
             }
         }
 
         if ($this->isSuccessful()) {
-            $message = $codes[0];
+            return $codes[0];
         }
 
-        return $message;
+        return 'PENDING';
     }
 
     /**
-     * Get transaction reference
+     * Get transaction reference provided with order (the ID in Omnipay parlance), and sent back with notifications.
      *
-     * @access public
-     * @return string
+     * @return string|null
      */
-    public function getTransactionReference()
+    public function getTransactionId()
     {
-        $attributes = $this->data->attributes();
+        if (empty($this->getOrder())) {
+            return null;
+        }
+
+        $attributes = $this->getOrder()->attributes();
 
         if (isset($attributes['orderCode'])) {
             return $attributes['orderCode'];
         }
+
+        return null;
+    }
+
+    /**
+     * Get *your* reference a.k.a Omnipay transaction ID (!)
+     *
+     * @return string
+     * @deprecated This was named inconsistently with other Omnipay adapters. Use getTransactionId(), whose name
+     * reflects the actual contents returned.
+     */
+    public function getTransactionReference()
+    {
+        return $this->getTransactionId();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getErrorCode()
+    {
+        if (!isset($this->data->error) || empty($this->data->error->attributes()['code'])) {
+            return null;
+        }
+
+        return (string) $this->data->error->attributes()['code'];
+    }
+
+    /**
+     * @return null|\SimpleXMLElement
+     */
+    public function getOrder()
+    {
+        if (isset($this->data->orderStatusEvent)) {
+            return $this->data->orderStatusEvent; // Notifications
+        }
+
+        if (isset($this->data->orderStatus)) {
+            return $this->data->orderStatus; // Order responses
+        }
+
+        return null;
     }
 
     /**
@@ -138,27 +196,28 @@ class Response extends AbstractResponse
      */
     public function isRedirect()
     {
-        if (isset($this->data->requestInfo->request3DSecure->issuerURL)) {
-            return true;
-        }
-
-        return false;
+        return isset($this->data->requestInfo->request3DSecure->issuerURL);
     }
 
     /**
-     * Get is successful
+     * Whether transaction's last state indicates success
      *
-     * @access public
-     * @return boolean
+     * @return bool
      */
     public function isSuccessful()
     {
-        if (isset($this->data->payment->lastEvent)) {
-            if (strtoupper($this->data->payment->lastEvent) == 'AUTHORISED') {
-                return true;
-            }
+        if (!isset($this->getOrder()->payment->lastEvent)) {
+            return false;
         }
 
-        return false;
+        return in_array(
+            strtoupper($this->getOrder()->payment->lastEvent),
+            [
+                self::$PAYMENT_STATUS_AUTHORISED,
+                self::$PAYMENT_STATUS_CAPTURED,
+                self::$PAYMENT_STATUS_SETTLED_BY_MERCHANT,
+            ],
+            true
+        );
     }
 }

--- a/src/Omnipay/WorldPayXML/Message/Response.php
+++ b/src/Omnipay/WorldPayXML/Message/Response.php
@@ -13,15 +13,15 @@ use Omnipay\Common\Message\RequestInterface;
 class Response extends AbstractResponse
 {
     /** @var string */
-    protected static $PAYMENT_STATUS_AUTHORISED             = 'AUTHORISED';
+    const PAYMENT_STATUS_AUTHORISED             = 'AUTHORISED';
     /** @var string */
-    protected static $PAYMENT_STATUS_CAPTURED               = 'CAPTURED';
+    const PAYMENT_STATUS_CAPTURED               = 'CAPTURED';
     /** @var string */
-    protected static $PAYMENT_STATUS_SETTLED_BY_MERCHANT    = 'SETTLED_BY_MERCHANT';
+    const PAYMENT_STATUS_SETTLED_BY_MERCHANT    = 'SETTLED_BY_MERCHANT';
     /** @var string */
-    protected static $PAYMENT_STATUS_SENT_FOR_AUTHORISATION = 'SENT_FOR_AUTHORISATION';
+    const PAYMENT_STATUS_SENT_FOR_AUTHORISATION = 'SENT_FOR_AUTHORISATION';
     /** @var string */
-    protected static $PAYMENT_STATUS_CANCELLED              = 'CANCELLED';
+    const PAYMENT_STATUS_CANCELLED              = 'CANCELLED';
 
     /**
      * @param RequestInterface $request Request
@@ -213,9 +213,9 @@ class Response extends AbstractResponse
         return in_array(
             strtoupper($this->getOrder()->payment->lastEvent),
             [
-                self::$PAYMENT_STATUS_AUTHORISED,
-                self::$PAYMENT_STATUS_CAPTURED,
-                self::$PAYMENT_STATUS_SETTLED_BY_MERCHANT,
+                self::PAYMENT_STATUS_AUTHORISED,
+                self::PAYMENT_STATUS_CAPTURED,
+                self::PAYMENT_STATUS_SETTLED_BY_MERCHANT,
             ],
             true
         );

--- a/tests/Omnipay/WorldPayXML/Message/ResponseTest.php
+++ b/tests/Omnipay/WorldPayXML/Message/ResponseTest.php
@@ -55,4 +55,66 @@ class ResponseTest extends TestCase
         $this->assertEquals('T0211234', $response->getTransactionReference());
         $this->assertSame('CARD EXPIRED', $response->getMessage());
     }
+
+    public function testPurchaseErrorGeneric()
+    {
+        $httpResponse = $this->getMockHttpResponse('PurchaseErrorGeneric.txt');
+
+        $response = new Response(
+            $this->getMockRequest(),
+            $httpResponse->getBody()
+        );
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ERROR: Nasty internal error!', $response->getMessage());
+        $this->assertNull($response->getErrorCode());
+    }
+
+    public function testPurchaseErrorDuplicateOrder()
+    {
+        $httpResponse = $this->getMockHttpResponse('PurchaseErrorDuplicateOrder.txt');
+
+        $response = new Response(
+            $this->getMockRequest(),
+            $httpResponse->getBody()
+        );
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ERROR: Duplicate Order', $response->getMessage());
+        $this->assertSame('5', $response->getErrorCode());
+    }
+
+    /**
+     * You can get this e.g. if you are authenticated but your merchant code in the body is wrong.
+     */
+    public function testPurchaseErrorSecurityFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('PurchaseErrorSecurityViolation.txt');
+
+        $response = new Response(
+            $this->getMockRequest(),
+            $httpResponse->getBody()
+        );
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ERROR: Security violation', $response->getMessage());
+        $this->assertSame('4', $response->getErrorCode());
+    }
+
+    /**
+     * @expectedException \Omnipay\Common\Exception\InvalidResponseException
+     * @expectedExceptionMessage Could not import response XML:
+     */
+    public function testPurchaseUnauthenticated()
+    {
+        $httpResponse = $this->getMockHttpResponse('PurchaseUnauthenticated.txt');
+
+        new Response(
+            $this->getMockRequest(),
+            $httpResponse->getBody()
+        );
+    }
 }

--- a/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorDuplicateOrder.txt
+++ b/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorDuplicateOrder.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/xml
+Content-length: 341
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MYMERCHANT"><reply><error code="5"><![CDATA[Duplicate Order]]></error></reply></paymentService>

--- a/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorGeneric.txt
+++ b/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorGeneric.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/xml
+Content-length: 376
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4.1" merchantCode="MYMERCHANT"><reply><error>Nasty internal error!</error></reply></paymentService>

--- a/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorSecurityViolation.txt
+++ b/tests/Omnipay/WorldPayXML/Mock/PurchaseErrorSecurityViolation.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/xml
+Content-length: 344
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MYMERCHANT"><reply><error code="4"><![CDATA[Security violation]]></error></reply></paymentService>

--- a/tests/Omnipay/WorldPayXML/Mock/PurchaseUnauthenticated.txt
+++ b/tests/Omnipay/WorldPayXML/Mock/PurchaseUnauthenticated.txt
@@ -1,0 +1,28 @@
+HTTP/1.1 401 Unauthorized
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/html
+Content-length: 767
+
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <title>401: Requires Authentication</title>
+        <style type="text/css" media="print"> @import url(/pictures/print.css);</style>
+        <style type="text/css" media="screen"> @import url(/pictures/adminstyle-branded.css);</style>
+    </head>
+    <body class="standalone">
+        <div class="content">
+            <span class="legend">Requires Authentication</span>
+            <div class="status">Status: 401</div>
+            <p>
+            This request requires HTTP authentication.
+
+                <br />
+            </p>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
* Support more secure 'username', distinct from merchant code
* Detect and handle errors better, especially generic CDATA text in an `<error>`

This is mostly copied from changes I made on the Hosted adapter, but because this one doesn't yet have models to handle Notifications, its `Response` methods are all directly in the class rather than partly in a shared Trait.